### PR TITLE
Refactor - crypto

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @aiblockofficial/core

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,9 +1,42 @@
 pub use ring;
-use std::convert::TryInto;
 use tracing::warn;
+use crate::utils::serialize_utils::FixedByteArray;
+
+macro_rules! fixed_bytes_wrapper {
+    ($vis:vis struct $name:ident, $n:expr, $doc:literal) => {
+        #[doc = $doc]
+        #[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize)]
+        $vis struct $name(crate::utils::serialize_utils::FixedByteArray<$n>);
+
+        impl $name {
+            pub fn from_slice(slice: &[u8]) -> Option<Self> {
+                Some(Self(slice.try_into().ok()?))
+            }
+        }
+
+        impl AsRef<[u8]> for $name {
+            fn as_ref(&self) -> &[u8] {
+                self.0.as_ref()
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                std::fmt::Display::fmt(&self.0, f)
+            }
+        }
+
+        impl std::str::FromStr for $name {
+            type Err = <crate::utils::serialize_utils::FixedByteArray<$n> as std::str::FromStr>::Err;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                <crate::utils::serialize_utils::FixedByteArray<$n> as std::str::FromStr>::from_str(s).map(Self)
+            }
+        }
+    };
+}
 
 pub mod sign_ed25519 {
-    use super::deserialize_slice;
     pub use ring::signature::Ed25519KeyPair as SecretKeyBase;
     use ring::signature::KeyPair;
     pub use ring::signature::Signature as SignatureBase;
@@ -21,53 +54,14 @@ pub mod sign_ed25519 {
     const SIGNATURE_LEN: usize = ELEM_LEN + SCALAR_LEN;
     pub const ED25519_SIGNATURE_LEN: usize = SIGNATURE_LEN;
 
-    /// Signature data
-    /// We used sodiumoxide serialization before (treated it as slice with 64 bit length prefix).
-    #[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize)]
-    pub struct Signature(
-        #[serde(serialize_with = "<[_]>::serialize")]
-        #[serde(deserialize_with = "deserialize_slice")]
-        [u8; ED25519_SIGNATURE_LEN],
-    );
-
-    impl Signature {
-        pub fn from_slice(slice: &[u8]) -> Option<Self> {
-            Some(Self(slice.try_into().ok()?))
-        }
-    }
-
-    impl AsRef<[u8]> for Signature {
-        fn as_ref(&self) -> &[u8] {
-            self.0.as_ref()
-        }
-    }
-
-    /// Public key data
-    /// We used sodiumoxide serialization before (treated it as slice with 64 bit length prefix).
-    #[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize)]
-    pub struct PublicKey(
-        #[serde(serialize_with = "<[_]>::serialize")]
-        #[serde(deserialize_with = "deserialize_slice")]
-        [u8; ED25519_PUBLIC_KEY_LEN],
-    );
-
-    impl PublicKey {
-        pub fn from_slice(slice: &[u8]) -> Option<Self> {
-            Some(Self(slice.try_into().ok()?))
-        }
-    }
-
-    impl AsRef<[u8]> for PublicKey {
-        fn as_ref(&self) -> &[u8] {
-            self.0.as_ref()
-        }
-    }
+    fixed_bytes_wrapper!(pub struct Signature, ED25519_SIGNATURE_LEN, "Signature data");
+    fixed_bytes_wrapper!(pub struct PublicKey, ED25519_PUBLIC_KEY_LEN, "Public key data");
 
     /// PKCS8 encoded secret key pair
     /// We used sodiumoxide serialization before (treated it as slice with 64 bit length prefix).
     /// Slice and vector are serialized the same.
     #[derive(Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize)]
-    pub struct SecretKey(Vec<u8>);
+    pub struct SecretKey(#[serde(with = "crate::utils::serialize_utils::vec_codec")] Vec<u8>);
 
     impl SecretKey {
         pub fn from_slice(slice: &[u8]) -> Option<Self> {
@@ -91,7 +85,7 @@ pub mod sign_ed25519 {
             Ok(secret) => secret,
             Err(_) => {
                 warn!("Invalid secret key");
-                return Signature([0; ED25519_SIGNATURE_LEN]);
+                return Signature([0; ED25519_SIGNATURE_LEN].into());
             }
         };
 
@@ -99,7 +93,7 @@ pub mod sign_ed25519 {
             Ok(signature) => signature,
             Err(_) => {
                 warn!("Invalid signature");
-                return Signature([0; ED25519_SIGNATURE_LEN]);
+                return Signature([0; ED25519_SIGNATURE_LEN].into());
             }
         };
         Signature(signature)
@@ -135,7 +129,7 @@ pub mod sign_ed25519 {
             Ok(pkcs8) => pkcs8,
             Err(_) => {
                 warn!("Failed to generate secret key base for pkcs8");
-                return (PublicKey([0; ED25519_PUBLIC_KEY_LEN]), SecretKey(vec![]));
+                return (PublicKey([0; ED25519_PUBLIC_KEY_LEN].into()), SecretKey(vec![]));
             }
         };
 
@@ -143,7 +137,7 @@ pub mod sign_ed25519 {
             Ok(secret) => secret,
             Err(_) => {
                 warn!("Invalid secret key base");
-                return (PublicKey([0; ED25519_PUBLIC_KEY_LEN]), SecretKey(vec![]));
+                return (PublicKey([0; ED25519_PUBLIC_KEY_LEN].into()), SecretKey(vec![]));
             }
         };
 
@@ -151,7 +145,7 @@ pub mod sign_ed25519 {
             Ok(pub_key_gen) => pub_key_gen,
             Err(_) => {
                 warn!("Invalid public key generation");
-                return (PublicKey([0; ED25519_PUBLIC_KEY_LEN]), SecretKey(vec![]));
+                return (PublicKey([0; ED25519_PUBLIC_KEY_LEN].into()), SecretKey(vec![]));
             }
         };
         let public = PublicKey(pub_key_gen);
@@ -159,7 +153,7 @@ pub mod sign_ed25519 {
             Some(secret) => secret,
             None => {
                 warn!("Invalid secret key");
-                return (PublicKey([0; ED25519_PUBLIC_KEY_LEN]), SecretKey(vec![]));
+                return (PublicKey([0; ED25519_PUBLIC_KEY_LEN].into()), SecretKey(vec![]));
             }
         };
 
@@ -169,7 +163,7 @@ pub mod sign_ed25519 {
 
 pub mod secretbox_chacha20_poly1305 {
     // Use key and nonce separately like rust-tls does
-    use super::{deserialize_slice, generate_random};
+    use super::generate_random;
     pub use ring::aead::LessSafeKey as KeyBase;
     pub use ring::aead::Nonce as NonceBase;
     pub use ring::aead::NONCE_LEN;
@@ -179,45 +173,8 @@ pub mod secretbox_chacha20_poly1305 {
 
     pub const KEY_LEN: usize = 256 / 8;
 
-    /// key data
-    #[derive(Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize)]
-    pub struct Key(
-        #[serde(serialize_with = "<[_]>::serialize")]
-        #[serde(deserialize_with = "deserialize_slice")]
-        [u8; KEY_LEN],
-    );
-
-    impl Key {
-        pub fn from_slice(slice: &[u8]) -> Option<Self> {
-            Some(Self(slice.try_into().ok()?))
-        }
-    }
-
-    impl AsRef<[u8]> for Key {
-        fn as_ref(&self) -> &[u8] {
-            self.0.as_ref()
-        }
-    }
-
-    /// Nonce data
-    #[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize)]
-    pub struct Nonce(
-        #[serde(serialize_with = "<[_]>::serialize")]
-        #[serde(deserialize_with = "deserialize_slice")]
-        [u8; NONCE_LEN],
-    );
-
-    impl Nonce {
-        pub fn from_slice(slice: &[u8]) -> Option<Self> {
-            Some(Self(slice.try_into().ok()?))
-        }
-    }
-
-    impl AsRef<[u8]> for Nonce {
-        fn as_ref(&self) -> &[u8] {
-            self.0.as_ref()
-        }
-    }
+    fixed_bytes_wrapper!(pub struct Key, KEY_LEN, "Key data");
+    fixed_bytes_wrapper!(pub struct Nonce, NONCE_LEN, "Nonce data");
 
     pub fn seal(mut plain_text: Vec<u8>, nonce: &Nonce, key: &Key) -> Option<Vec<u8>> {
         let key = get_keybase(key)?;
@@ -249,7 +206,7 @@ pub mod secretbox_chacha20_poly1305 {
     }
 
     fn get_noncebase(nonce: &Nonce) -> NonceBase {
-        NonceBase::assume_unique_for_key(nonce.0)
+        NonceBase::assume_unique_for_key(*nonce.0)
     }
 
     pub fn gen_key() -> Key {
@@ -262,7 +219,7 @@ pub mod secretbox_chacha20_poly1305 {
 }
 
 pub mod pbkdf2 {
-    use super::{deserialize_slice, generate_random};
+    use super::generate_random;
     use ring::pbkdf2::{derive, PBKDF2_HMAC_SHA256};
     use serde::{Deserialize, Serialize};
     use std::convert::TryInto;
@@ -272,24 +229,7 @@ pub mod pbkdf2 {
     pub const SALT_LEN: usize = 256 / 8;
     pub const OPSLIMIT_INTERACTIVE: u32 = 100_000;
 
-    #[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize)]
-    pub struct Salt(
-        #[serde(serialize_with = "<[_]>::serialize")]
-        #[serde(deserialize_with = "deserialize_slice")]
-        [u8; SALT_LEN],
-    );
-
-    impl Salt {
-        pub fn from_slice(slice: &[u8]) -> Option<Self> {
-            Some(Self(slice.try_into().ok()?))
-        }
-    }
-
-    impl AsRef<[u8]> for Salt {
-        fn as_ref(&self) -> &[u8] {
-            self.0.as_ref()
-        }
-    }
+    fixed_bytes_wrapper!(pub struct Salt, SALT_LEN, "Salt data");
 
     pub fn derive_key(key: &mut [u8], passwd: &[u8], salt: &Salt, iterations: u32) {
         let iterations = match NonZeroU32::new(iterations) {
@@ -374,16 +314,7 @@ pub mod sha3_256 {
     }
 }
 
-fn deserialize_slice<'de, D: serde::Deserializer<'de>, const N: usize>(
-    deserializer: D,
-) -> Result<[u8; N], D::Error> {
-    let value: &[u8] = serde::Deserialize::deserialize(deserializer)?;
-    value
-        .try_into()
-        .map_err(|_| serde::de::Error::custom("Invalid array in deserialization".to_string()))
-}
-
-pub fn generate_random<const N: usize>() -> [u8; N] {
+fn generate_random<const N: usize>() -> FixedByteArray<N> {
     let mut value: [u8; N] = [0; N];
 
     use ring::rand::SecureRandom;
@@ -393,5 +324,5 @@ pub fn generate_random<const N: usize>() -> [u8; N] {
         Err(_) => warn!("Failed to generate random bytes"),
     };
 
-    value
+    FixedByteArray::new(value)
 }

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -308,18 +308,69 @@ pub mod pbkdf2 {
 }
 
 pub mod sha3_256 {
+    use std::convert::{TryFrom, TryInto};
+    use std::fmt::{Display, Formatter};
+    use std::ops::Deref;
+    use std::str::FromStr;
+
     pub use sha3::digest::Output;
     pub use sha3::Digest;
     pub use sha3::Sha3_256;
 
-    pub fn digest(data: &[u8]) -> Output<Sha3_256> {
-        Sha3_256::digest(data)
+    pub const HASH_LEN : usize = 256 / 8;
+
+    /// A SHA3-256 hash.
+    #[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq)]
+    pub struct Hash(
+        [u8; HASH_LEN],
+    );
+
+    impl Hash {
+        pub fn from_slice(slice: &[u8]) -> Option<Self> {
+            Some(Self(slice.try_into().ok()?))
+        }
     }
 
-    pub fn digest_all<'a>(data: impl Iterator<Item = &'a [u8]>) -> Output<Sha3_256> {
+    impl Display for Hash {
+        fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+            f.write_str(&hex::encode(&self.0))
+        }
+    }
+
+    impl FromStr for Hash {
+        type Err = hex::FromHexError;
+
+        fn from_str(s: &str) -> Result<Self, Self::Err> {
+            let mut buf = [0u8; HASH_LEN];
+            match hex::decode_to_slice(s, &mut buf) {
+                Ok(_) => Ok(Self(buf)),
+                Err(e) => Err(e),
+            }
+        }
+    }
+
+    impl AsRef<[u8]> for Hash {
+        fn as_ref(&self) -> &[u8] {
+            &self.0
+        }
+    }
+
+    impl Deref for Hash {
+        type Target = [u8; HASH_LEN];
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    pub fn digest(data: &[u8]) -> Hash {
+        Hash(Sha3_256::digest(data).try_into().unwrap())
+    }
+
+    pub fn digest_all<'a>(data: impl Iterator<Item = &'a [u8]>) -> Hash {
         let mut hasher = Sha3_256::new();
         data.for_each(|v| hasher.update(v));
-        hasher.finalize()
+        Hash(hasher.finalize().try_into().unwrap())
     }
 }
 

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -52,7 +52,7 @@ pub mod sign_ed25519 {
     pub use ring::signature::{ED25519, ED25519_PUBLIC_KEY_LEN};
     use serde::{Deserialize, Serialize};
     use std::convert::TryInto;
-    use crate::crypto::generate_random;
+    use crate::crypto::generate_secure_random;
 
     // Constants copied from the ring library
     const SCALAR_LEN: usize = 32;
@@ -131,7 +131,7 @@ pub mod sign_ed25519 {
 
     pub fn sign_detached(msg: &[u8], sk: &SecretKey) -> Signature {
         let keypair = SecretKeyBase::from_pkcs8(sk.as_ref())
-                .expect("Invalid PKCS8 secret key?!?");
+            .expect("Invalid PKCS8 secret key?!?");
 
         let signature = keypair.sign(msg).as_ref().try_into()
             .expect("Invalid signature?!?");
@@ -140,7 +140,7 @@ pub mod sign_ed25519 {
 
     /// Generates a completely random Ed25519 keypair.
     pub fn gen_keypair() -> (PublicKey, SecretKey) {
-        let seed = generate_random();
+        let seed = generate_secure_random();
         gen_keypair_from_seed(&seed)
     }
 
@@ -170,7 +170,7 @@ pub mod sign_ed25519 {
 
 pub mod secretbox_chacha20_poly1305 {
     // Use key and nonce separately like rust-tls does
-    use super::generate_random;
+    use super::generate_secure_random;
     pub use ring::aead::LessSafeKey as KeyBase;
     pub use ring::aead::Nonce as NonceBase;
     pub use ring::aead::NONCE_LEN;
@@ -217,16 +217,16 @@ pub mod secretbox_chacha20_poly1305 {
     }
 
     pub fn gen_key() -> Key {
-        Key(generate_random().into())
+        Key(generate_secure_random().into())
     }
 
     pub fn gen_nonce() -> Nonce {
-        Nonce(generate_random().into())
+        Nonce(generate_secure_random().into())
     }
 }
 
 pub mod pbkdf2 {
-    use super::generate_random;
+    use super::generate_secure_random;
     use ring::pbkdf2::{derive, PBKDF2_HMAC_SHA256};
     use serde::{Deserialize, Serialize};
     use std::convert::TryInto;
@@ -250,7 +250,7 @@ pub mod pbkdf2 {
     }
 
     pub fn gen_salt() -> Salt {
-        Salt(generate_random().into())
+        Salt(generate_secure_random().into())
     }
 }
 
@@ -342,16 +342,12 @@ pub mod sha3_256 {
     }
 }
 
-fn generate_random<const N: usize>() -> [u8; N] {
-    let mut value: [u8; N] = [0; N];
-
+fn generate_secure_random<const N: usize>() -> [u8; N] {
     use ring::rand::SecureRandom;
     let rand = ring::rand::SystemRandom::new();
-    match rand.fill(&mut value) {
-        Ok(_) => (),
-        Err(_) => warn!("Failed to generate random bytes"),
-    };
 
+    let mut value = [0u8; N];
+    rand.fill(&mut value).expect("Failed to generate random bytes");
     value
 }
 


### PR DESCRIPTION
## Description

This PR depends on #42 (`placeholders`) and #43 (`serialize-utils`).

This PR refactors the structs in the `crypto` module to consistently implement all the same traits, serialize to human-readable representations, and implement `Placeholder`+`PlaceholderSeed`.

## Changelog

- Replaced all structs under `crypto` which represent a fixed-length byte array with a macro
  - This macro handles serialization, display, parsing and placeholder value generation
- Removed a few functions which were never used, such as `sign_append`
- Made keypair generation actually panic in the face of impossible errors, rather than logging a warning and returning an invalid keypair

## Type of Change
Please mark the appropriate option by putting an "x" inside the brackets:

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement or optimization
- [ ] Documentation update
- [ ] Other (please specify)

## Checklist
Put an "x" in the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have tested the changes locally and they work as expected.
- [x] I have added necessary documentation or updated existing documentation.
- [x] My code follows the project's coding standards and style guidelines.
- [x] I have added/updated relevant tests to ensure the changes are properly covered.
- [x] I have checked for and resolved any merge conflicts.
- [x] My commits have clear and descriptive messages.

## Screenshots (if applicable)
If the changes affect the UI or have visual effects, please provide screenshots or GIFs showcasing the changes.

## Additional Context (if applicable)
Add any additional context or information about the changes that may be helpful in understanding the pull request.

## Related Issues (if applicable)
If this pull request is related to any existing issues, please list them here.

## Requested Reviewers
Mention any specific individuals or teams you would like to request a review from.