### PR TITLE
Refactor - crypto-usages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @aiblockofficial/core

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,9 +1,42 @@
 pub use ring;
-use std::convert::TryInto;
 use tracing::warn;
+use crate::utils::serialize_utils::FixedByteArray;
+
+macro_rules! fixed_bytes_wrapper {
+    ($vis:vis struct $name:ident, $n:expr, $doc:literal) => {
+        #[doc = $doc]
+        #[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize)]
+        $vis struct $name(crate::utils::serialize_utils::FixedByteArray<$n>);
+
+        impl $name {
+            pub fn from_slice(slice: &[u8]) -> Option<Self> {
+                Some(Self(slice.try_into().ok()?))
+            }
+        }
+
+        impl AsRef<[u8]> for $name {
+            fn as_ref(&self) -> &[u8] {
+                self.0.as_ref()
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                std::fmt::Display::fmt(&self.0, f)
+            }
+        }
+
+        impl std::str::FromStr for $name {
+            type Err = <crate::utils::serialize_utils::FixedByteArray<$n> as std::str::FromStr>::Err;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                <crate::utils::serialize_utils::FixedByteArray<$n> as std::str::FromStr>::from_str(s).map(Self)
+            }
+        }
+    };
+}
 
 pub mod sign_ed25519 {
-    use super::deserialize_slice;
     pub use ring::signature::Ed25519KeyPair as SecretKeyBase;
     use ring::signature::KeyPair;
     pub use ring::signature::Signature as SignatureBase;
@@ -21,53 +54,14 @@ pub mod sign_ed25519 {
     const SIGNATURE_LEN: usize = ELEM_LEN + SCALAR_LEN;
     pub const ED25519_SIGNATURE_LEN: usize = SIGNATURE_LEN;
 
-    /// Signature data
-    /// We used sodiumoxide serialization before (treated it as slice with 64 bit length prefix).
-    #[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize)]
-    pub struct Signature(
-        #[serde(serialize_with = "<[_]>::serialize")]
-        #[serde(deserialize_with = "deserialize_slice")]
-        [u8; ED25519_SIGNATURE_LEN],
-    );
-
-    impl Signature {
-        pub fn from_slice(slice: &[u8]) -> Option<Self> {
-            Some(Self(slice.try_into().ok()?))
-        }
-    }
-
-    impl AsRef<[u8]> for Signature {
-        fn as_ref(&self) -> &[u8] {
-            self.0.as_ref()
-        }
-    }
-
-    /// Public key data
-    /// We used sodiumoxide serialization before (treated it as slice with 64 bit length prefix).
-    #[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize)]
-    pub struct PublicKey(
-        #[serde(serialize_with = "<[_]>::serialize")]
-        #[serde(deserialize_with = "deserialize_slice")]
-        [u8; ED25519_PUBLIC_KEY_LEN],
-    );
-
-    impl PublicKey {
-        pub fn from_slice(slice: &[u8]) -> Option<Self> {
-            Some(Self(slice.try_into().ok()?))
-        }
-    }
-
-    impl AsRef<[u8]> for PublicKey {
-        fn as_ref(&self) -> &[u8] {
-            self.0.as_ref()
-        }
-    }
+    fixed_bytes_wrapper!(pub struct Signature, ED25519_SIGNATURE_LEN, "Signature data");
+    fixed_bytes_wrapper!(pub struct PublicKey, ED25519_PUBLIC_KEY_LEN, "Public key data");
 
     /// PKCS8 encoded secret key pair
     /// We used sodiumoxide serialization before (treated it as slice with 64 bit length prefix).
     /// Slice and vector are serialized the same.
     #[derive(Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize)]
-    pub struct SecretKey(Vec<u8>);
+    pub struct SecretKey(#[serde(with = "crate::utils::serialize_utils::vec_codec")] Vec<u8>);
 
     impl SecretKey {
         pub fn from_slice(slice: &[u8]) -> Option<Self> {
@@ -91,7 +85,7 @@ pub mod sign_ed25519 {
             Ok(secret) => secret,
             Err(_) => {
                 warn!("Invalid secret key");
-                return Signature([0; ED25519_SIGNATURE_LEN]);
+                return Signature([0; ED25519_SIGNATURE_LEN].into());
             }
         };
 
@@ -99,7 +93,7 @@ pub mod sign_ed25519 {
             Ok(signature) => signature,
             Err(_) => {
                 warn!("Invalid signature");
-                return Signature([0; ED25519_SIGNATURE_LEN]);
+                return Signature([0; ED25519_SIGNATURE_LEN].into());
             }
         };
         Signature(signature)
@@ -135,7 +129,7 @@ pub mod sign_ed25519 {
             Ok(pkcs8) => pkcs8,
             Err(_) => {
                 warn!("Failed to generate secret key base for pkcs8");
-                return (PublicKey([0; ED25519_PUBLIC_KEY_LEN]), SecretKey(vec![]));
+                return (PublicKey([0; ED25519_PUBLIC_KEY_LEN].into()), SecretKey(vec![]));
             }
         };
 
@@ -143,7 +137,7 @@ pub mod sign_ed25519 {
             Ok(secret) => secret,
             Err(_) => {
                 warn!("Invalid secret key base");
-                return (PublicKey([0; ED25519_PUBLIC_KEY_LEN]), SecretKey(vec![]));
+                return (PublicKey([0; ED25519_PUBLIC_KEY_LEN].into()), SecretKey(vec![]));
             }
         };
 
@@ -151,7 +145,7 @@ pub mod sign_ed25519 {
             Ok(pub_key_gen) => pub_key_gen,
             Err(_) => {
                 warn!("Invalid public key generation");
-                return (PublicKey([0; ED25519_PUBLIC_KEY_LEN]), SecretKey(vec![]));
+                return (PublicKey([0; ED25519_PUBLIC_KEY_LEN].into()), SecretKey(vec![]));
             }
         };
         let public = PublicKey(pub_key_gen);
@@ -159,7 +153,7 @@ pub mod sign_ed25519 {
             Some(secret) => secret,
             None => {
                 warn!("Invalid secret key");
-                return (PublicKey([0; ED25519_PUBLIC_KEY_LEN]), SecretKey(vec![]));
+                return (PublicKey([0; ED25519_PUBLIC_KEY_LEN].into()), SecretKey(vec![]));
             }
         };
 
@@ -169,7 +163,7 @@ pub mod sign_ed25519 {
 
 pub mod secretbox_chacha20_poly1305 {
     // Use key and nonce separately like rust-tls does
-    use super::{deserialize_slice, generate_random};
+    use super::generate_random;
     pub use ring::aead::LessSafeKey as KeyBase;
     pub use ring::aead::Nonce as NonceBase;
     pub use ring::aead::NONCE_LEN;
@@ -179,45 +173,8 @@ pub mod secretbox_chacha20_poly1305 {
 
     pub const KEY_LEN: usize = 256 / 8;
 
-    /// key data
-    #[derive(Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize)]
-    pub struct Key(
-        #[serde(serialize_with = "<[_]>::serialize")]
-        #[serde(deserialize_with = "deserialize_slice")]
-        [u8; KEY_LEN],
-    );
-
-    impl Key {
-        pub fn from_slice(slice: &[u8]) -> Option<Self> {
-            Some(Self(slice.try_into().ok()?))
-        }
-    }
-
-    impl AsRef<[u8]> for Key {
-        fn as_ref(&self) -> &[u8] {
-            self.0.as_ref()
-        }
-    }
-
-    /// Nonce data
-    #[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize)]
-    pub struct Nonce(
-        #[serde(serialize_with = "<[_]>::serialize")]
-        #[serde(deserialize_with = "deserialize_slice")]
-        [u8; NONCE_LEN],
-    );
-
-    impl Nonce {
-        pub fn from_slice(slice: &[u8]) -> Option<Self> {
-            Some(Self(slice.try_into().ok()?))
-        }
-    }
-
-    impl AsRef<[u8]> for Nonce {
-        fn as_ref(&self) -> &[u8] {
-            self.0.as_ref()
-        }
-    }
+    fixed_bytes_wrapper!(pub struct Key, KEY_LEN, "Key data");
+    fixed_bytes_wrapper!(pub struct Nonce, NONCE_LEN, "Nonce data");
 
     pub fn seal(mut plain_text: Vec<u8>, nonce: &Nonce, key: &Key) -> Option<Vec<u8>> {
         let key = get_keybase(key)?;
@@ -249,7 +206,7 @@ pub mod secretbox_chacha20_poly1305 {
     }
 
     fn get_noncebase(nonce: &Nonce) -> NonceBase {
-        NonceBase::assume_unique_for_key(nonce.0)
+        NonceBase::assume_unique_for_key(*nonce.0)
     }
 
     pub fn gen_key() -> Key {
@@ -262,7 +219,7 @@ pub mod secretbox_chacha20_poly1305 {
 }
 
 pub mod pbkdf2 {
-    use super::{deserialize_slice, generate_random};
+    use super::generate_random;
     use ring::pbkdf2::{derive, PBKDF2_HMAC_SHA256};
     use serde::{Deserialize, Serialize};
     use std::convert::TryInto;
@@ -272,24 +229,7 @@ pub mod pbkdf2 {
     pub const SALT_LEN: usize = 256 / 8;
     pub const OPSLIMIT_INTERACTIVE: u32 = 100_000;
 
-    #[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize)]
-    pub struct Salt(
-        #[serde(serialize_with = "<[_]>::serialize")]
-        #[serde(deserialize_with = "deserialize_slice")]
-        [u8; SALT_LEN],
-    );
-
-    impl Salt {
-        pub fn from_slice(slice: &[u8]) -> Option<Self> {
-            Some(Self(slice.try_into().ok()?))
-        }
-    }
-
-    impl AsRef<[u8]> for Salt {
-        fn as_ref(&self) -> &[u8] {
-            self.0.as_ref()
-        }
-    }
+    fixed_bytes_wrapper!(pub struct Salt, SALT_LEN, "Salt data");
 
     pub fn derive_key(key: &mut [u8], passwd: &[u8], salt: &Salt, iterations: u32) {
         let iterations = match NonZeroU32::new(iterations) {
@@ -374,16 +314,7 @@ pub mod sha3_256 {
     }
 }
 
-fn deserialize_slice<'de, D: serde::Deserializer<'de>, const N: usize>(
-    deserializer: D,
-) -> Result<[u8; N], D::Error> {
-    let value: &[u8] = serde::Deserialize::deserialize(deserializer)?;
-    value
-        .try_into()
-        .map_err(|_| serde::de::Error::custom("Invalid array in deserialization".to_string()))
-}
-
-pub fn generate_random<const N: usize>() -> [u8; N] {
+fn generate_random<const N: usize>() -> FixedByteArray<N> {
     let mut value: [u8; N] = [0; N];
 
     use ring::rand::SecureRandom;
@@ -393,5 +324,5 @@ pub fn generate_random<const N: usize>() -> [u8; N] {
         Err(_) => warn!("Failed to generate random bytes"),
     };
 
-    value
+    FixedByteArray::new(value)
 }

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -308,18 +308,69 @@ pub mod pbkdf2 {
 }
 
 pub mod sha3_256 {
+    use std::convert::{TryFrom, TryInto};
+    use std::fmt::{Display, Formatter};
+    use std::ops::Deref;
+    use std::str::FromStr;
+
     pub use sha3::digest::Output;
     pub use sha3::Digest;
     pub use sha3::Sha3_256;
 
-    pub fn digest(data: &[u8]) -> Output<Sha3_256> {
-        Sha3_256::digest(data)
+    pub const HASH_LEN : usize = 256 / 8;
+
+    /// A SHA3-256 hash.
+    #[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq)]
+    pub struct Hash(
+        [u8; HASH_LEN],
+    );
+
+    impl Hash {
+        pub fn from_slice(slice: &[u8]) -> Option<Self> {
+            Some(Self(slice.try_into().ok()?))
+        }
     }
 
-    pub fn digest_all<'a>(data: impl Iterator<Item = &'a [u8]>) -> Output<Sha3_256> {
+    impl Display for Hash {
+        fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+            f.write_str(&hex::encode(&self.0))
+        }
+    }
+
+    impl FromStr for Hash {
+        type Err = hex::FromHexError;
+
+        fn from_str(s: &str) -> Result<Self, Self::Err> {
+            let mut buf = [0u8; HASH_LEN];
+            match hex::decode_to_slice(s, &mut buf) {
+                Ok(_) => Ok(Self(buf)),
+                Err(e) => Err(e),
+            }
+        }
+    }
+
+    impl AsRef<[u8]> for Hash {
+        fn as_ref(&self) -> &[u8] {
+            &self.0
+        }
+    }
+
+    impl Deref for Hash {
+        type Target = [u8; HASH_LEN];
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    pub fn digest(data: &[u8]) -> Hash {
+        Hash(Sha3_256::digest(data).try_into().unwrap())
+    }
+
+    pub fn digest_all<'a>(data: impl Iterator<Item = &'a [u8]>) -> Hash {
         let mut hasher = Sha3_256::new();
         data.for_each(|v| hasher.update(v));
-        hasher.finalize()
+        Hash(hasher.finalize().try_into().unwrap())
     }
 }
 

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -52,7 +52,7 @@ pub mod sign_ed25519 {
     pub use ring::signature::{ED25519, ED25519_PUBLIC_KEY_LEN};
     use serde::{Deserialize, Serialize};
     use std::convert::TryInto;
-    use crate::crypto::generate_random;
+    use crate::crypto::generate_secure_random;
 
     // Constants copied from the ring library
     const SCALAR_LEN: usize = 32;
@@ -131,7 +131,7 @@ pub mod sign_ed25519 {
 
     pub fn sign_detached(msg: &[u8], sk: &SecretKey) -> Signature {
         let keypair = SecretKeyBase::from_pkcs8(sk.as_ref())
-                .expect("Invalid PKCS8 secret key?!?");
+            .expect("Invalid PKCS8 secret key?!?");
 
         let signature = keypair.sign(msg).as_ref().try_into()
             .expect("Invalid signature?!?");
@@ -140,7 +140,7 @@ pub mod sign_ed25519 {
 
     /// Generates a completely random Ed25519 keypair.
     pub fn gen_keypair() -> (PublicKey, SecretKey) {
-        let seed = generate_random();
+        let seed = generate_secure_random();
         gen_keypair_from_seed(&seed)
     }
 
@@ -170,7 +170,7 @@ pub mod sign_ed25519 {
 
 pub mod secretbox_chacha20_poly1305 {
     // Use key and nonce separately like rust-tls does
-    use super::generate_random;
+    use super::generate_secure_random;
     pub use ring::aead::LessSafeKey as KeyBase;
     pub use ring::aead::Nonce as NonceBase;
     pub use ring::aead::NONCE_LEN;
@@ -217,16 +217,16 @@ pub mod secretbox_chacha20_poly1305 {
     }
 
     pub fn gen_key() -> Key {
-        Key(generate_random().into())
+        Key(generate_secure_random().into())
     }
 
     pub fn gen_nonce() -> Nonce {
-        Nonce(generate_random().into())
+        Nonce(generate_secure_random().into())
     }
 }
 
 pub mod pbkdf2 {
-    use super::generate_random;
+    use super::generate_secure_random;
     use ring::pbkdf2::{derive, PBKDF2_HMAC_SHA256};
     use serde::{Deserialize, Serialize};
     use std::convert::TryInto;
@@ -250,7 +250,7 @@ pub mod pbkdf2 {
     }
 
     pub fn gen_salt() -> Salt {
-        Salt(generate_random().into())
+        Salt(generate_secure_random().into())
     }
 }
 
@@ -342,16 +342,12 @@ pub mod sha3_256 {
     }
 }
 
-fn generate_random<const N: usize>() -> [u8; N] {
-    let mut value: [u8; N] = [0; N];
-
+fn generate_secure_random<const N: usize>() -> [u8; N] {
     use ring::rand::SecureRandom;
     let rand = ring::rand::SystemRandom::new();
-    match rand.fill(&mut value) {
-        Ok(_) => (),
-        Err(_) => warn!("Failed to generate random bytes"),
-    };
 
+    let mut value = [0u8; N];
+    rand.fill(&mut value).expect("Failed to generate random bytes");
     value
 }
 

--- a/src/utils/druid_utils.rs
+++ b/src/utils/druid_utils.rs
@@ -62,10 +62,10 @@ mod tests {
     use std::vec;
 
     use super::*;
-    use crate::crypto::sign_ed25519::{self as sign};
     use crate::primitives::asset::{Asset, ItemAsset, TokenAmount};
     use crate::primitives::druid::{DdeValues, DruidExpectation};
     use crate::primitives::transaction::*;
+    use crate::utils::Placeholder;
     use crate::utils::transaction_utils::*;
 
     /// Util function to create valid DDE asset tx's
@@ -74,7 +74,7 @@ mod tests {
         let tx_input = construct_payment_tx_ins(vec![]);
         let from_addr = construct_tx_ins_address(&tx_input);
 
-        let (pk, sk) = sign::gen_keypair();
+        let (pk, sk) = Placeholder::placeholder();
         let prev_out = OutPoint::new("t_hash".to_string(), 0);
         let mut key_material = BTreeMap::new();
         key_material.insert(prev_out, (pk, sk));
@@ -167,7 +167,7 @@ mod tests {
             let excess_tx_out =
                 TxOut::new_token_amount(sender_address_excess, amount - payment, None);
             
-            let (pk, sk) = sign::gen_keypair();
+            let (pk, sk) = Placeholder::placeholder();
             let prev_out = OutPoint::new("t_hash".to_string(), 0);
             key_material.insert(prev_out, (pk, sk));
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -9,6 +9,7 @@ pub mod druid_utils;
 pub mod error_utils;
 pub mod script_utils;
 pub mod serialize_utils;
+#[cfg(test)]
 pub mod test_utils;
 pub mod transaction_utils;
 

--- a/src/utils/script_utils.rs
+++ b/src/utils/script_utils.rs
@@ -304,6 +304,7 @@ mod tests {
     use crate::primitives::asset::Asset;
     use crate::primitives::druid::DdeValues;
     use crate::primitives::transaction::OutPoint;
+    use crate::utils::{Placeholder, PlaceholderIndexed};
     use crate::utils::test_utils::generate_tx_with_ins_and_outs_assets;
     use crate::utils::transaction_utils::*;
 
@@ -1895,7 +1896,7 @@ mod tests {
     /// Test OP_SHA3
     fn test_sha3() {
         /// op_sha3([sig]) -> [sha3_256(sig)]
-        let (pk, sk) = sign::gen_keypair();
+        let (pk, sk) = Placeholder::placeholder();
         let msg = hex::encode(vec![0, 0, 0]);
         let sig = sign::sign_detached(msg.as_bytes(), &sk);
         let h = hex::encode(sha3_256::digest(sig.as_ref()));
@@ -1934,7 +1935,7 @@ mod tests {
     /// Test OP_HASH256
     fn test_hash256() {
         /// op_hash256([pk]) -> [addr]
-        let (pk, sk) = sign::gen_keypair();
+        let (pk, sk) = Placeholder::placeholder();
         let mut stack = Stack::new();
         stack.push(StackEntry::PubKey(pk));
         let mut v: Vec<StackEntry> = vec![StackEntry::Bytes(construct_address(&pk))];
@@ -1950,7 +1951,7 @@ mod tests {
     /// Test OP_HASH256_V0
     fn test_hash256_v0() {
         /// op_hash256_v0([pk]) -> [addr_v0]
-        let (pk, sk) = sign::gen_keypair();
+        let (pk, sk) = Placeholder::placeholder();
         let mut stack = Stack::new();
         stack.push(StackEntry::PubKey(pk));
         let mut v: Vec<StackEntry> = vec![StackEntry::Bytes(construct_address_v0(&pk))];
@@ -1966,7 +1967,7 @@ mod tests {
     /// Test OP_HASH256_TEMP
     fn test_hash256_temp() {
         /// op_hash256_temp([pk]) -> [addr_temp]
-        let (pk, sk) = sign::gen_keypair();
+        let (pk, sk) = Placeholder::placeholder();
         let mut stack = Stack::new();
         stack.push(StackEntry::PubKey(pk));
         let mut v: Vec<StackEntry> = vec![StackEntry::Bytes(construct_address_temp(&pk))];
@@ -1982,13 +1983,13 @@ mod tests {
     /// Test OP_CHECKSIG
     fn test_checksig() {
         /// op_checksig([msg,sig,pk]) -> [1]
-        let (pk, sk) = sign::gen_keypair();
+        let (pk1, sk1) = PlaceholderIndexed::placeholder_indexed(1);
         let msg = hex::encode(vec![0, 0, 0]);
-        let sig = sign::sign_detached(msg.as_bytes(), &sk);
+        let sig = sign::sign_detached(msg.as_bytes(), &sk1);
         let mut stack = Stack::new();
         stack.push(StackEntry::Bytes(msg));
         stack.push(StackEntry::Signature(sig));
-        stack.push(StackEntry::PubKey(pk));
+        stack.push(StackEntry::PubKey(pk1));
         let mut v: Vec<StackEntry> = vec![StackEntry::Num(1)];
         op_checksig(&mut stack);
         assert_eq!(stack.main_stack, v);
@@ -1998,18 +1999,18 @@ mod tests {
         let mut stack = Stack::new();
         stack.push(StackEntry::Bytes(msg));
         stack.push(StackEntry::Signature(sig));
-        stack.push(StackEntry::PubKey(pk));
+        stack.push(StackEntry::PubKey(pk1));
         let mut v: Vec<StackEntry> = vec![StackEntry::Num(0)];
         op_checksig(&mut stack);
         assert_eq!(stack.main_stack, v);
         /// wrong public key
         /// op_checksig([msg,sig,pk']) -> [0]
-        let (pk, sk) = sign::gen_keypair();
+        let (pk2, sk2) = PlaceholderIndexed::placeholder_indexed(2);
         let msg = hex::encode(vec![0, 0, 0]);
         let mut stack = Stack::new();
         stack.push(StackEntry::Bytes(msg));
         stack.push(StackEntry::Signature(sig));
-        stack.push(StackEntry::PubKey(pk));
+        stack.push(StackEntry::PubKey(pk2));
         let mut v: Vec<StackEntry> = vec![StackEntry::Num(0)];
         op_checksig(&mut stack);
         assert_eq!(stack.main_stack, v);
@@ -2017,7 +2018,7 @@ mod tests {
         /// op_checksig([sig,pk]) -> fail
         let mut stack = Stack::new();
         stack.push(StackEntry::Signature(sig));
-        stack.push(StackEntry::PubKey(pk));
+        stack.push(StackEntry::PubKey(pk2));
         let b = op_checksig(&mut stack);
         assert!(!b)
     }
@@ -2026,13 +2027,13 @@ mod tests {
     /// Test OP_CHECKSIGVERIFY
     fn test_checksigverify() {
         /// op_checksigverify([msg,sig,pk]) -> []
-        let (pk, sk) = sign::gen_keypair();
+        let (pk1, sk1) = PlaceholderIndexed::placeholder_indexed(1);
         let msg = hex::encode(vec![0, 0, 0]);
-        let sig = sign::sign_detached(msg.as_bytes(), &sk);
+        let sig = sign::sign_detached(msg.as_bytes(), &sk1);
         let mut stack = Stack::new();
         stack.push(StackEntry::Bytes(msg));
         stack.push(StackEntry::Signature(sig));
-        stack.push(StackEntry::PubKey(pk));
+        stack.push(StackEntry::PubKey(pk1));
         let mut v: Vec<StackEntry> = vec![];
         op_checksigverify(&mut stack);
         assert_eq!(stack.main_stack, v);
@@ -2042,24 +2043,24 @@ mod tests {
         let mut stack = Stack::new();
         stack.push(StackEntry::Bytes(msg));
         stack.push(StackEntry::Signature(sig));
-        stack.push(StackEntry::PubKey(pk));
+        stack.push(StackEntry::PubKey(pk1));
         let b = op_checksigverify(&mut stack);
         assert!(!b);
         /// wrong public key
         /// op_checksig([msg,sig,pk']) -> fail
-        let (pk, sk) = sign::gen_keypair();
+        let (pk2, sk2) = PlaceholderIndexed::placeholder_indexed(2);
         let msg = hex::encode(vec![0, 0, 0]);
         let mut stack = Stack::new();
         stack.push(StackEntry::Bytes(msg));
         stack.push(StackEntry::Signature(sig));
-        stack.push(StackEntry::PubKey(pk));
+        stack.push(StackEntry::PubKey(pk2));
         let b = op_checksigverify(&mut stack);
         assert!(!b);
         /// no message
         /// op_checksigverify([sig,pk]) -> fail
         let mut stack = Stack::new();
         stack.push(StackEntry::Signature(sig));
-        stack.push(StackEntry::PubKey(pk));
+        stack.push(StackEntry::PubKey(pk2));
         let b = op_checksigverify(&mut stack);
         assert!(!b)
     }
@@ -2069,9 +2070,9 @@ mod tests {
     fn test_checkmultisig() {
         /// 2-of-3 multisig
         /// op_checkmultisig([msg,sig1,sig2,2,pk1,pk2,pk3,3]) -> [1]
-        let (pk1, sk1) = sign::gen_keypair();
-        let (pk2, sk2) = sign::gen_keypair();
-        let (pk3, sk3) = sign::gen_keypair();
+        let (pk1, sk1) = PlaceholderIndexed::placeholder_indexed(1);
+        let (pk2, sk2) = PlaceholderIndexed::placeholder_indexed(2);
+        let (pk3, sk3) = PlaceholderIndexed::placeholder_indexed(3);
         let msg = hex::encode(vec![0, 0, 0]);
         let sig1 = sign::sign_detached(msg.as_bytes(), &sk1);
         let sig2 = sign::sign_detached(msg.as_bytes(), &sk2);
@@ -2222,9 +2223,9 @@ mod tests {
     fn test_checkmultisigverify() {
         /// 2-of-3 multisig
         /// op_checkmultisigverify([msg,sig1,sig2,2,pk1,pk2,pk3,3]) -> []
-        let (pk1, sk1) = sign::gen_keypair();
-        let (pk2, sk2) = sign::gen_keypair();
-        let (pk3, sk3) = sign::gen_keypair();
+        let (pk1, sk1) = Placeholder::placeholder();
+        let (pk2, sk2) = Placeholder::placeholder();
+        let (pk3, sk3) = Placeholder::placeholder();
         let msg = hex::encode(vec![0, 0, 0]);
         let sig1 = sign::sign_detached(msg.as_bytes(), &sk1);
         let sig2 = sign::sign_detached(msg.as_bytes(), &sk2);
@@ -2678,7 +2679,7 @@ mod tests {
     fn test_pass_create_script_valid() {
         let asset = Asset::item(1, None, None);
         let asset_hash = construct_tx_in_signable_asset_hash(&asset);
-        let (pk, sk) = sign::gen_keypair();
+        let (pk, sk) = Placeholder::placeholder();
         let signature = sign::sign_detached(asset_hash.as_bytes(), &sk);
 
         let script = Script::new_create_asset(0, asset_hash, signature, pk);
@@ -2691,7 +2692,7 @@ mod tests {
         let metadata = String::from_utf8_lossy(&[0; MAX_METADATA_BYTES + 1]).to_string();
         let asset = Asset::item(1, None, Some(metadata));
         let asset_hash = construct_tx_in_signable_asset_hash(&asset);
-        let (pk, sk) = sign::gen_keypair();
+        let (pk, sk) = Placeholder::placeholder();
         let signature = sign::sign_detached(asset_hash.as_bytes(), &sk);
 
         let script = Script::new_create_asset(0, asset_hash, signature, pk);
@@ -2701,7 +2702,7 @@ mod tests {
     #[test]
     /// Checks whether addresses are validated correctly
     fn test_validate_addresses_correctly() {
-        let (pk, _) = sign::gen_keypair();
+        let (pk, _) = Placeholder::placeholder();
         let address = construct_address(&pk);
 
         assert!(address_has_valid_length(&address));
@@ -2728,7 +2729,7 @@ mod tests {
     }
 
     fn test_pass_member_multisig_valid_common(address_version: Option<u64>) {
-        let (pk, sk) = sign::gen_keypair();
+        let (pk, sk) = Placeholder::placeholder();
         let t_hash = hex::encode(vec![0, 0, 0]);
         let signature = sign::sign_detached(t_hash.as_bytes(), &sk);
 
@@ -2763,15 +2764,15 @@ mod tests {
     }
 
     fn test_fail_member_multisig_invalid_common(address_version: Option<u64>) {
-        let (_pk, sk) = sign::gen_keypair();
-        let (pk, _sk) = sign::gen_keypair();
+        let (_pk1, sk1) = PlaceholderIndexed::placeholder_indexed(1);
+        let (pk2, _sk2) = PlaceholderIndexed::placeholder_indexed(2);
         let t_hash = hex::encode(vec![0, 0, 0]);
-        let signature = sign::sign_detached(t_hash.as_bytes(), &sk);
+        let signature = sign::sign_detached(t_hash.as_bytes(), &sk1);
 
         let tx_const = TxConstructor {
             previous_out: OutPoint::new(t_hash, 0),
             signatures: vec![signature],
-            pub_keys: vec![pk],
+            pub_keys: vec![pk2],
             address_version,
         };
 
@@ -2787,7 +2788,7 @@ mod tests {
     }
 
     fn test_pass_p2pkh_sig_valid_common(address_version: Option<u64>) {
-        let (pk, sk) = sign::gen_keypair();
+        let (pk, sk) = Placeholder::placeholder();
         let outpoint = OutPoint {
             t_hash: hex::encode(vec![0, 0, 0]),
             n: 0,
@@ -2829,8 +2830,8 @@ mod tests {
     }
 
     fn test_fail_p2pkh_sig_invalid_common(address_version: Option<u64>) {
-        let (pk, sk) = sign::gen_keypair();
-        let (second_pk, _s) = sign::gen_keypair();
+        let (pk, sk) = Placeholder::placeholder();
+        let (second_pk, _s) = Placeholder::placeholder();
         let outpoint = OutPoint {
             t_hash: hex::encode(vec![0, 0, 0]),
             n: 0,
@@ -2875,7 +2876,7 @@ mod tests {
     }
 
     fn test_fail_p2pkh_sig_script_empty_common(address_version: Option<u64>) {
-        let (pk, sk) = sign::gen_keypair();
+        let (pk, sk) = Placeholder::placeholder();
         let outpoint = OutPoint {
             t_hash: hex::encode(vec![0, 0, 0]),
             n: 0,
@@ -2929,7 +2930,7 @@ mod tests {
     }
 
     fn test_fail_p2pkh_sig_script_invalid_struct_common(address_version: Option<u64>) {
-        let (pk, sk) = sign::gen_keypair();
+        let (pk, sk) = Placeholder::placeholder();
         let outpoint = OutPoint {
             t_hash: hex::encode(vec![0, 0, 0]),
             n: 0,
@@ -2987,9 +2988,9 @@ mod tests {
     }
 
     fn test_pass_multisig_validation_valid_common(address_version: Option<u64>) {
-        let (first_pk, first_sk) = sign::gen_keypair();
-        let (second_pk, second_sk) = sign::gen_keypair();
-        let (third_pk, third_sk) = sign::gen_keypair();
+        let (first_pk, first_sk) = Placeholder::placeholder();
+        let (second_pk, second_sk) = Placeholder::placeholder();
+        let (third_pk, third_sk) = Placeholder::placeholder();
         let check_data = hex::encode(vec![0, 0, 0]);
 
         let m = 2;
@@ -3060,7 +3061,7 @@ mod tests {
         //
         // Arrange
         //
-        let (pk, sk) = sign::gen_keypair();
+        let (pk, sk) = Placeholder::placeholder();
         let tx_hash = hex::encode(vec![0, 0, 0]);
         let tx_outpoint = OutPoint::new(tx_hash, 0);
         let script_public_key = construct_address_for(&pk, address_version);
@@ -3300,8 +3301,8 @@ mod tests {
     }
 
     fn test_fail_interpret_valid_common(address_version: Option<u64>) {
-        let (_pk, sk) = sign::gen_keypair();
-        let (pk, _sk) = sign::gen_keypair();
+        let (_pk, sk) = PlaceholderIndexed::placeholder_indexed(0);
+        let (pk, _sk) = PlaceholderIndexed::placeholder_indexed(1);
         let t_hash = hex::encode(vec![0, 0, 0]);
         let signature = sign::sign_detached(t_hash.as_bytes(), &sk);
 
@@ -3336,7 +3337,7 @@ mod tests {
     }
 
     fn test_pass_interpret_valid_common(address_version: Option<u64>) {
-        let (pk, sk) = sign::gen_keypair();
+        let (pk, sk) = Placeholder::placeholder();
         let t_hash = hex::encode(vec![0, 0, 0]);
         let signature = sign::sign_detached(t_hash.as_bytes(), &sk);
 

--- a/src/utils/test_utils.rs
+++ b/src/utils/test_utils.rs
@@ -1,4 +1,3 @@
-use crate::crypto::sign_ed25519::{self as sign};
 use crate::primitives::asset::Asset;
 use crate::primitives::{
     asset::TokenAmount,
@@ -7,6 +6,8 @@ use crate::primitives::{
 use crate::script::lang::Script;
 use crate::utils::transaction_utils::{construct_address, construct_tx_in_out_signable_hash};
 use std::collections::BTreeMap;
+use crate::crypto::sign_ed25519;
+use crate::utils::Placeholder;
 
 /// Generate a transaction with valid Script values
 /// and accompanying UTXO set for testing a set of
@@ -29,7 +30,7 @@ pub fn generate_tx_with_ins_and_outs_assets(
     input_assets: &[(u64, Option<&str>, Option<String>)], /* Input amount, genesis_hash, metadata */
     output_assets: &[(u64, Option<&str>)],                /* Input amount, genesis_hash */
 ) -> (BTreeMap<OutPoint, TxOut>, Transaction) {
-    let (pk, sk) = sign::gen_keypair();
+    let (pk, sk) = Placeholder::placeholder();
     let spk = construct_address(&pk);
     let mut tx = Transaction::new();
     let mut utxo_set: BTreeMap<OutPoint, TxOut> = BTreeMap::new();
@@ -63,7 +64,7 @@ pub fn generate_tx_with_ins_and_outs_assets(
             },
             &tx.outputs,
         );
-        let signature = sign::sign_detached(signable_hash.as_bytes(), &sk);
+        let signature = sign_ed25519::sign_detached(signable_hash.as_bytes(), &sk);
         let tx_in = TxIn::new_from_input(
             tx_previous_out.clone(),
             Script::pay2pkh(signable_hash, signature, pk, None),

--- a/src/utils/transaction_utils.rs
+++ b/src/utils/transaction_utils.rs
@@ -735,9 +735,10 @@ pub fn construct_dde_tx(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::crypto::sign_ed25519::{self as sign, Signature};
+    use crate::crypto::sign_ed25519::{self, self as sign, Signature};
     use crate::primitives::asset::{AssetValues, ItemAsset, TokenAmount};
     use crate::script::OpCodes;
+    use crate::utils::Placeholder;
     use crate::utils::script_utils::{tx_has_valid_p2sh_script, tx_outs_are_valid};
 
     #[test]
@@ -759,10 +760,9 @@ mod tests {
     }
 
     fn test_construct_valid_inputs(address_version: Option<u64>) -> (Vec<TxIn>, String, BTreeMap<OutPoint, (PublicKey, SecretKey)>) {
-        let (_pk, sk) = sign::gen_keypair();
-        let (pk, _sk) = sign::gen_keypair();
+        let (pk, sk) = Placeholder::placeholder();
         let t_hash = vec![0, 0, 0];
-        let signature = sign::sign_detached(&t_hash, &sk);
+        let signature = sign_ed25519::sign_detached(&t_hash, &sk);
         let drs_block_hash = hex::encode(vec![1, 2, 3, 4, 5, 6]);
         let mut key_material = BTreeMap::new();
         let prev_out = OutPoint::new(hex::encode(t_hash), 0);
@@ -915,8 +915,7 @@ mod tests {
     #[test]
     /// Creates a valid payment transaction including fees
     fn test_token_onspend_with_fees() {
-        let (_pk, sk) = sign::gen_keypair();
-        let (pk, _sk) = sign::gen_keypair();
+        let (pk, sk) = Placeholder::placeholder();
         let t_hash = vec![0, 0, 0];
         let signature = sign::sign_detached(&t_hash, &sk);
         let tokens = TokenAmount(400000);
@@ -959,8 +958,7 @@ mod tests {
     #[test]
     /// Checks the validity of on-spend for items with fees
     fn test_item_onspend_with_fees() {
-        let (_pk, sk) = sign::gen_keypair();
-        let (pk, _sk) = sign::gen_keypair();
+        let (pk, sk) = Placeholder::placeholder();
         let t_hash = vec![0, 0, 0];
         let signature = sign::sign_detached(&t_hash, &sk);
         let fees = TokenAmount(1000);
@@ -1007,8 +1005,7 @@ mod tests {
     #[test]
     /// Checks the validity of the metadata on-spend for items
     fn test_item_onspend_metadata() {
-        let (_pk, sk) = sign::gen_keypair();
-        let (pk, _sk) = sign::gen_keypair();
+        let (pk, sk) = Placeholder::placeholder();
         let t_hash = vec![0, 0, 0];
         let signature = sign::sign_detached(&t_hash, &sk);
         let prev_out = OutPoint::new(hex::encode(t_hash), 0);
@@ -1068,7 +1065,7 @@ mod tests {
     }
 
     fn test_construct_valid_utxo_set_common(address_version: Option<u64>) {
-        let (pk, sk) = sign::gen_keypair();
+        let (pk, sk) = Placeholder::placeholder();
 
         let t_hash_1 = hex::encode(vec![0, 0, 0]);
         let signed = sign::sign_detached(t_hash_1.as_bytes(), &sk);
@@ -1150,8 +1147,7 @@ mod tests {
     }
 
     fn test_construct_a_valid_dde_tx_common(address_version: Option<u64>) {
-        let (_pk, sk) = sign::gen_keypair();
-        let (pk, _sk) = sign::gen_keypair();
+        let (pk, sk) = Placeholder::placeholder();
         let t_hash = hex::encode(vec![0, 0, 0]);
         let signature = sign::sign_detached(t_hash.as_bytes(), &sk);
         let prev_out = OutPoint::new(hex::encode(&t_hash), 0);
@@ -1225,7 +1221,7 @@ mod tests {
 
         let sender_address_excess = "11112".to_owned();
 
-        let (pk, sk) = sign::gen_keypair();
+        let (pk, sk) = Placeholder::placeholder();
         let mut key_material = BTreeMap::new();
 
         // Act

--- a/src/utils/transaction_utils.rs
+++ b/src/utils/transaction_utils.rs
@@ -1,6 +1,6 @@
 use crate::constants::*;
 use crate::crypto::sha3_256;
-use crate::crypto::sign_ed25519::{self as sign, sign_detached, PublicKey, SecretKey};
+use crate::crypto::sign_ed25519::{self, PublicKey, SecretKey};
 use crate::primitives::asset::Asset;
 use crate::primitives::druid::{DdeValues, DruidExpectation};
 use crate::primitives::transaction::*;
@@ -369,7 +369,7 @@ pub fn construct_create_tx_in(
     secret_key: &SecretKey,
 ) -> Vec<TxIn> {
     let asset_hash = construct_tx_in_signable_asset_hash(asset);
-    let signature = sign::sign_detached(asset_hash.as_bytes(), secret_key);
+    let signature = sign_ed25519::sign_detached(asset_hash.as_bytes(), secret_key);
 
     vec![TxIn {
         previous_out: None,
@@ -579,7 +579,7 @@ pub fn update_input_signatures(tx_ins: &[TxIn], tx_outs: &[TxOut], key_material:
     
             let script_signature = Script::pay2pkh(
                 signable_hash.clone(),
-                sign_detached(signable_hash.as_bytes(), sk),
+                sign_ed25519::sign_detached(signable_hash.as_bytes(), sk),
                 pk,
                 None,
             );
@@ -735,7 +735,7 @@ pub fn construct_dde_tx(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::crypto::sign_ed25519::{self, self as sign, Signature};
+    use crate::crypto::sign_ed25519::Signature;
     use crate::primitives::asset::{AssetValues, ItemAsset, TokenAmount};
     use crate::script::OpCodes;
     use crate::utils::Placeholder;
@@ -917,7 +917,7 @@ mod tests {
     fn test_token_onspend_with_fees() {
         let (pk, sk) = Placeholder::placeholder();
         let t_hash = vec![0, 0, 0];
-        let signature = sign::sign_detached(&t_hash, &sk);
+        let signature = sign_ed25519::sign_detached(&t_hash, &sk);
         let tokens = TokenAmount(400000);
         let fees = TokenAmount(1000);
         let prev_out = OutPoint::new(hex::encode(t_hash), 0);
@@ -960,7 +960,7 @@ mod tests {
     fn test_item_onspend_with_fees() {
         let (pk, sk) = Placeholder::placeholder();
         let t_hash = vec![0, 0, 0];
-        let signature = sign::sign_detached(&t_hash, &sk);
+        let signature = sign_ed25519::sign_detached(&t_hash, &sk);
         let fees = TokenAmount(1000);
         let prev_out = OutPoint::new(hex::encode(t_hash), 0);
         let mut key_material = BTreeMap::new();
@@ -1007,7 +1007,7 @@ mod tests {
     fn test_item_onspend_metadata() {
         let (pk, sk) = Placeholder::placeholder();
         let t_hash = vec![0, 0, 0];
-        let signature = sign::sign_detached(&t_hash, &sk);
+        let signature = sign_ed25519::sign_detached(&t_hash, &sk);
         let prev_out = OutPoint::new(hex::encode(t_hash), 0);
         let mut key_material = BTreeMap::new();
         key_material.insert(prev_out.clone(), (pk, sk));
@@ -1068,7 +1068,7 @@ mod tests {
         let (pk, sk) = Placeholder::placeholder();
 
         let t_hash_1 = hex::encode(vec![0, 0, 0]);
-        let signed = sign::sign_detached(t_hash_1.as_bytes(), &sk);
+        let signed = sign_ed25519::sign_detached(t_hash_1.as_bytes(), &sk);
 
         let prev_out = OutPoint::new(hex::encode(t_hash_1), 0);
         let mut key_material = BTreeMap::new();
@@ -1149,7 +1149,7 @@ mod tests {
     fn test_construct_a_valid_dde_tx_common(address_version: Option<u64>) {
         let (pk, sk) = Placeholder::placeholder();
         let t_hash = hex::encode(vec![0, 0, 0]);
-        let signature = sign::sign_detached(t_hash.as_bytes(), &sk);
+        let signature = sign_ed25519::sign_detached(t_hash.as_bytes(), &sk);
         let prev_out = OutPoint::new(hex::encode(&t_hash), 0);
         let mut key_material = BTreeMap::new();
         key_material.insert(prev_out.clone(), (pk, sk));


### PR DESCRIPTION
## Description
This PR depends on #45 (`crypto`).

This cleans up many of the references to the `crypto` module across the project with more idiomatic equivalents.

## Changelog

- Make all code stop using `crypto::sign_ed25519 as sign`
- Replaced all references to `sign_ed25519::gen_keypair()` in tests with `placeholder()`, or one of the seeded placeholder functions where consistency between test runs is desirable

## Type of Change
Please mark the appropriate option by putting an "x" inside the brackets:

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement or optimization
- [ ] Documentation update
- [ ] Other (please specify)

## Checklist
Put an "x" in the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have tested the changes locally and they work as expected.
- [x] I have added necessary documentation or updated existing documentation.
- [x] My code follows the project's coding standards and style guidelines.
- [x] I have added/updated relevant tests to ensure the changes are properly covered.
- [x] I have checked for and resolved any merge conflicts.
- [x] My commits have clear and descriptive messages.

## Screenshots (if applicable)
If the changes affect the UI or have visual effects, please provide screenshots or GIFs showcasing the changes.

## Additional Context (if applicable)
Add any additional context or information about the changes that may be helpful in understanding the pull request.

## Related Issues (if applicable)
If this pull request is related to any existing issues, please list them here.

## Requested Reviewers
Mention any specific individuals or teams you would like to request a review from.