### PR TITLE
Refactor - No address versions

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -5,7 +5,6 @@ pub const MAX_METADATA_BYTES: usize = 800;
 pub const TX_HASH_LENGTH: usize = 32;
 
 /*------- ADDRESS CONSTANTS -------*/
-pub const V0_ADDRESS_LENGTH: usize = 16;
 pub const STANDARD_ADDRESS_LENGTH: usize = 64;
 // Prepending character for a P2SH address
 pub const P2SH_PREPEND: u8 = b'H';
@@ -14,11 +13,6 @@ pub const P2SH_PREPEND: u8 = b'H';
 // Current network version: Always bump immediately after a version is deployed.
 pub const NETWORK_VERSION: u32 = 6;
 pub const NETWORK_VERSION_SERIALIZED: &[u8] = b"6";
-// Network version 0
-pub const NETWORK_VERSION_V0: u64 = 0;
-// Network version to support temporary address structure on wallet
-// TODO: Deprecate after addresses retire
-pub const NETWORK_VERSION_TEMP: u64 = 99999;
 
 /*------- VALUE HANDLING CONSTANTS --------*/
 // Number of decimal places to divide to in display
@@ -229,8 +223,6 @@ pub const OPWITHIN_DESC: &str = "Substitutes the three numbers on top of the the
 // crypto
 pub const OPSHA3: &str = "OP_SHA3";
 pub const OPHASH256: &str = "OP_HASH256";
-pub const OPHASH256V0: &str = "OP_HASH256_V0";
-pub const OPHASH256TEMP: &str = "OP_HASH256_TEMP";
 pub const OPCHECKSIG: &str = "OP_CHECKSIG";
 pub const OPCHECKSIGVERIFY: &str = "OP_CHECKSIGVERIFY";
 pub const OPCHECKMULTISIG: &str = "OP_CHECKMULTISIG";
@@ -239,10 +231,6 @@ pub const OPCHECKMULTISIGVERIFY: &str = "OP_CHECKMULTISIGVERIFY";
 pub const OPSHA3_DESC: &str = "Hashes the top item on the stack using SHA3-256";
 pub const OPHASH256_DESC: &str =
     "Creates standard address from public key and pushes it onto the stack";
-pub const OPHASH256V0_DESC: &str =
-    "Creates v0 address from public key and pushes it onto the stack";
-pub const OPHASH256TEMP_DESC: &str =
-    "Creates temporary address from public key and pushes it onto the stack";
 pub const OPCHECKSIG_DESC: &str =
     "Pushes ONE onto the stack if the signature is valid, ZERO otherwise";
 pub const OPCHECKSIGVERIFY_DESC: &str = "Runs OP_CHECKSIG and OP_VERIFY in sequence";

--- a/src/primitives/transaction.rs
+++ b/src/primitives/transaction.rs
@@ -35,7 +35,6 @@ pub struct TxConstructor {
     pub previous_out: OutPoint,
     pub signatures: Vec<Signature>,
     pub pub_keys: Vec<PublicKey>,
-    pub address_version: Option<u64>,
 }
 
 /// An outpoint - a combination of a transaction hash and an index n into its vout

--- a/src/script/interface_ops.rs
+++ b/src/script/interface_ops.rs
@@ -8,9 +8,7 @@ use crate::primitives::transaction::*;
 use crate::script::lang::{ConditionStack, Script, Stack};
 use crate::script::{OpCodes, StackEntry};
 use crate::utils::error_utils::*;
-use crate::utils::transaction_utils::{
-    construct_address, construct_address_temp, construct_address_v0,
-};
+use crate::utils::transaction_utils::construct_address;
 use bincode::de;
 use bincode::serialize;
 use bytes::Bytes;
@@ -1982,64 +1980,6 @@ pub fn op_hash256(stack: &mut Stack) -> bool {
     };
     let addr = construct_address(&pk);
     stack.push(StackEntry::Bytes(hex::decode(addr).unwrap()))
-}
-
-/// OP_HASH256_V0: Creates v0 address from public key and pushes it onto the stack
-///
-/// Example: OP_HASH256_V0([pk]) -> [addr_v0]
-///
-/// Info: Support for old 32-byte addresses
-///
-/// TODO: Deprecate after addresses retire
-///
-/// ### Arguments
-///
-/// * `stack`  - mutable reference to the stack
-pub fn op_hash256_v0(stack: &mut Stack) -> bool {
-    let (op, desc) = (OPHASH256V0, OPHASH256V0_DESC);
-    trace(op, desc);
-    let pk = match stack.pop() {
-        Some(StackEntry::PubKey(pk)) => pk,
-        Some(_) => {
-            error_item_type(op);
-            return false;
-        }
-        _ => {
-            error_num_items(op);
-            return false;
-        }
-    };
-    let addr_v0 = construct_address_v0(&pk);
-    stack.push(StackEntry::Bytes(hex::decode(addr_v0).unwrap()))
-}
-
-/// OP_HASH256_TEMP: Creates temporary address from public key and pushes it onto the stack
-///
-/// Example: OP_HASH256_TEMP([pk]) -> [addr_temp]
-///
-/// Info: Support for temporary address scheme used in wallet
-///
-/// TODO: Deprecate after addresses retire
-///
-/// ### Arguments
-///
-/// * `stack`  - mutable reference to the stack
-pub fn op_hash256_temp(stack: &mut Stack) -> bool {
-    let (op, desc) = (OPHASH256TEMP, OPHASH256TEMP_DESC);
-    trace(op, desc);
-    let pk = match stack.pop() {
-        Some(StackEntry::PubKey(pk)) => pk,
-        Some(_) => {
-            error_item_type(op);
-            return false;
-        }
-        _ => {
-            error_num_items(op);
-            return false;
-        }
-    };
-    let addr_temp = construct_address_temp(&pk);
-    stack.push(StackEntry::Bytes(hex::decode(addr_temp).unwrap()))
 }
 
 /// OP_CHECKSIG: Pushes ONE onto the stack if the signature is valid, ZERO otherwise

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -109,8 +109,6 @@ pub enum OpCodes {
     // crypto
     OP_SHA3 = 0x90,
     OP_HASH256 = 0x91,
-    OP_HASH256_V0 = 0x92,
-    OP_HASH256_TEMP = 0x93,
     OP_CHECKSIG = 0x94,
     OP_CHECKSIGVERIFY = 0x95,
     OP_CHECKMULTISIG = 0x96,
@@ -128,6 +126,8 @@ pub enum OpCodes {
     OP_NOP8 = 0xb7,
     OP_NOP9 = 0xb8,
     OP_NOP10 = 0xb9,
+    OP_NOP11 = 0x92, // Formerly OP_HASH256_V0
+    OP_NOP12 = 0x93, // Formerly OP_HASH256_TEMP
 }
 
 impl OpCodes {

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -12,8 +12,9 @@ pub enum StackEntry {
     Op(OpCodes),
     Signature(Signature),
     PubKey(PublicKey),
+    // TODO: This should probably be u64, as usize doesn't have a consistent range on all platforms
     Num(usize),
-    Bytes(String),
+    Bytes(Vec<u8>),
 }
 
 /// Opcodes enum

--- a/src/utils/test_utils.rs
+++ b/src/utils/test_utils.rs
@@ -66,7 +66,7 @@ pub fn generate_tx_with_ins_and_outs_assets(
         let signature = sign::sign_detached(signable_hash.as_bytes(), &sk);
         let tx_in = TxIn::new_from_input(
             tx_previous_out.clone(),
-            Script::pay2pkh(hex::decode(&signable_hash).unwrap(), signature, pk, None),
+            Script::pay2pkh(hex::decode(&signable_hash).unwrap(), signature, pk),
         );
         utxo_set.insert(tx_previous_out, tx_in_previous_out);
         tx.inputs.push(tx_in);

--- a/src/utils/test_utils.rs
+++ b/src/utils/test_utils.rs
@@ -66,7 +66,7 @@ pub fn generate_tx_with_ins_and_outs_assets(
         let signature = sign::sign_detached(signable_hash.as_bytes(), &sk);
         let tx_in = TxIn::new_from_input(
             tx_previous_out.clone(),
-            Script::pay2pkh(signable_hash, signature, pk, None),
+            Script::pay2pkh(hex::decode(&signable_hash).unwrap(), signature, pk, None),
         );
         utxo_set.insert(tx_previous_out, tx_in_previous_out);
         tx.inputs.push(tx_in);

--- a/src/utils/transaction_utils.rs
+++ b/src/utils/transaction_utils.rs
@@ -162,7 +162,7 @@ pub fn get_stack_entry_signable_string(entry: &StackEntry) -> String {
         }
         StackEntry::PubKey(pub_key) => format!("PubKey:{}", hex::encode(pub_key.as_ref())),
         StackEntry::Num(num) => format!("Num:{num}"),
-        StackEntry::Bytes(bytes) => format!("Bytes:{bytes}"),
+        StackEntry::Bytes(bytes) => format!("Bytes:{}", hex::encode(bytes)),
     }
 }
 
@@ -578,7 +578,7 @@ pub fn update_input_signatures(tx_ins: &[TxIn], tx_outs: &[TxOut], key_material:
             let sk = &key_material.get(&previous_out.unwrap()).unwrap().1;
     
             let script_signature = Script::pay2pkh(
-                signable_hash.clone(),
+                hex::decode(&signable_hash).unwrap(),
                 sign_detached(signable_hash.as_bytes(), sk),
                 pk,
                 None,
@@ -1472,7 +1472,7 @@ mod tests {
                     Signature::from_slice(hex::decode(signatures[n]).unwrap().as_ref()).unwrap();
                 let pk = PublicKey::from_slice(hex::decode(pub_keys[n]).unwrap().as_ref()).unwrap();
 
-                let script = Script::pay2pkh(sig_data, sig, pk, None);
+                let script = Script::pay2pkh(hex::decode(&sig_data).unwrap(), sig, pk, None);
                 let out_p = previous_out_points[n].clone();
 
                 TxIn::new_from_input(out_p, script)

--- a/src/utils/transaction_utils.rs
+++ b/src/utils/transaction_utils.rs
@@ -31,20 +31,6 @@ pub fn construct_p2sh_address(script: &Script) -> String {
     addr
 }
 
-/// Builds an address from a public key and a specified network version
-///
-/// ### Arguments
-///
-/// * `pub_key` - A public key to build an address from
-/// * `address_version` - Network version to use for the address
-pub fn construct_address_for(pub_key: &PublicKey, address_version: Option<u64>) -> String {
-    match address_version {
-        Some(NETWORK_VERSION_V0) => construct_address_v0(pub_key),
-        Some(NETWORK_VERSION_TEMP) => construct_address_temp(pub_key),
-        _ => construct_address(pub_key),
-    }
-}
-
 /// Builds an address from a public key
 ///
 /// ### Arguments
@@ -52,58 +38,6 @@ pub fn construct_address_for(pub_key: &PublicKey, address_version: Option<u64>) 
 /// * `pub_key` - A public key to build an address from
 pub fn construct_address(pub_key: &PublicKey) -> String {
     hex::encode(sha3_256::digest(pub_key.as_ref()))
-}
-
-/// Builds an old (network version 0) address from a public key
-///
-/// ### Arguments
-///
-/// * `pub_key` - A public key to build an address from
-pub fn construct_address_v0(pub_key: &PublicKey) -> String {
-    let first_pubkey_bytes = {
-        // We used sodiumoxide serialization before with a 64 bit length prefix.
-        // Make clear what we are using as this was not intended.
-        let mut v = vec![32, 0, 0, 0, 0, 0, 0, 0];
-        v.extend_from_slice(pub_key.as_ref());
-        v
-    };
-    let mut first_hash = sha3_256::digest(&first_pubkey_bytes).to_vec();
-    first_hash.truncate(V0_ADDRESS_LENGTH);
-    hex::encode(first_hash)
-}
-
-/// Builds an address from a public key using the
-/// temporary address scheme present on the wallet
-///
-/// TODO: Deprecate after addresses retire
-///
-/// ### Arguments
-///
-/// * `pub_key` - A public key to build an address from
-pub fn construct_address_temp(pub_key: &PublicKey) -> String {
-    let base64_encoding = base64::encode(pub_key.as_ref());
-    let hex_decoded = decode_base64_as_hex(&base64_encoding);
-    hex::encode(sha3_256::digest(&hex_decoded))
-}
-
-/// Decodes a base64 encoded string as hex, invalid character pairs are decoded up to the
-/// first character. If the decoding up to the first character fails, a default value of 0
-/// is used.
-///
-/// TODO: Deprecate after addresses retire
-///
-/// ### Arguments
-///
-/// * `s`   - Base64 encoded string
-pub fn decode_base64_as_hex(s: &str) -> Vec<u8> {
-    (ZERO..s.len())
-        .step_by(TWO)
-        .map(|i| {
-            u8::from_str_radix(&s[i..i + TWO], SIXTEEN as u32)
-                .or_else(|_| u8::from_str_radix(&s[i..i + ONE], SIXTEEN as u32))
-                .unwrap_or_default()
-        })
-        .collect()
 }
 
 /// Constructs signable string for OutPoint
@@ -581,7 +515,6 @@ pub fn update_input_signatures(tx_ins: &[TxIn], tx_outs: &[TxOut], key_material:
                 hex::decode(&signable_hash).unwrap(),
                 sign_detached(signable_hash.as_bytes(), sk),
                 pk,
-                None,
             );
     
             tx_in.script_signature = script_signature;
@@ -740,25 +673,7 @@ mod tests {
     use crate::script::OpCodes;
     use crate::utils::script_utils::{tx_has_valid_p2sh_script, tx_outs_are_valid};
 
-    #[test]
-    // Creates a valid payment transaction
-    fn test_construct_a_valid_payment_tx() {
-        test_construct_a_valid_payment_tx_common(None);
-    }
-
-    #[test]
-    // Creates a valid payment transaction
-    fn test_construct_a_valid_payment_tx_v0() {
-        test_construct_a_valid_payment_tx_common(Some(NETWORK_VERSION_V0));
-    }
-
-    #[test]
-    // Creates a valid payment transaction
-    fn test_construct_a_valid_payment_tx_temp() {
-        test_construct_a_valid_payment_tx_common(Some(NETWORK_VERSION_TEMP));
-    }
-
-    fn test_construct_valid_inputs(address_version: Option<u64>) -> (Vec<TxIn>, String, BTreeMap<OutPoint, (PublicKey, SecretKey)>) {
+    fn test_construct_valid_inputs() -> (Vec<TxIn>, String, BTreeMap<OutPoint, (PublicKey, SecretKey)>) {
         let (_pk, sk) = sign::gen_keypair();
         let (pk, _sk) = sign::gen_keypair();
         let t_hash = vec![0, 0, 0];
@@ -773,7 +688,6 @@ mod tests {
             previous_out: prev_out,
             signatures: vec![signature],
             pub_keys: vec![pk],
-            address_version,
         };
 
         let tx_ins = construct_payment_tx_ins(vec![tx_const]);
@@ -784,7 +698,7 @@ mod tests {
     #[test]
     fn test_construct_a_valid_p2sh_tx() {
         let token_amount = TokenAmount(400000);
-        let (tx_ins, _drs_block_hash, key_material) = test_construct_valid_inputs(Some(NETWORK_VERSION_V0));
+        let (tx_ins, _drs_block_hash, key_material) = test_construct_valid_inputs();
         let mut script = Script::new_for_coinbase(10);
         script.stack.push(StackEntry::Op(OpCodes::OP_DROP));
 
@@ -796,7 +710,6 @@ mod tests {
             previous_out: OutPoint::new(spending_tx_hash, 0),
             signatures: vec![],
             pub_keys: vec![],
-            address_version: Some(NETWORK_VERSION_V0),
         };
 
         let redeeming_tx_ins = construct_p2sh_redeem_tx_ins(tx_const, script.clone());
@@ -826,7 +739,7 @@ mod tests {
     #[test]
     fn test_construct_a_valid_burn_tx() {
         let token_amount = TokenAmount(400000);
-        let (tx_ins, _drs_block_hash, key_material) = test_construct_valid_inputs(Some(NETWORK_VERSION_V0));
+        let (tx_ins, _drs_block_hash, key_material) = test_construct_valid_inputs();
 
         let burn_tx = construct_burn_tx(tx_ins, None, &key_material);
 
@@ -836,7 +749,6 @@ mod tests {
             previous_out: OutPoint::new(spending_tx_hash, 0),
             signatures: vec![],
             pub_keys: vec![],
-            address_version: Some(NETWORK_VERSION_V0),
         };
 
         let s = vec![StackEntry::Op(OpCodes::OP_BURN)];
@@ -867,8 +779,9 @@ mod tests {
         // TODO: Add assertion for full tx validity
     }
 
-    fn test_construct_a_valid_payment_tx_common(address_version: Option<u64>) {
-        let (tx_ins, _drs_block_hash, key_material) = test_construct_valid_inputs(address_version);
+    #[test]
+    fn test_construct_a_valid_payment_tx() {
+        let (tx_ins, _drs_block_hash, key_material) = test_construct_valid_inputs();
 
         let token_amount = TokenAmount(400000);
         let payment_tx = construct_payment_tx(
@@ -891,7 +804,7 @@ mod tests {
     #[test]
     /// Creates a valid payment transaction including fees
     fn test_construct_valid_payment_tx_with_fees() {
-        let (tx_ins, _drs_block_hash, key_material) = test_construct_valid_inputs(None);
+        let (tx_ins, _drs_block_hash, key_material) = test_construct_valid_inputs();
 
         let token_amount = TokenAmount(400000);
         let fee_amount = TokenAmount(1000);
@@ -929,7 +842,6 @@ mod tests {
             previous_out: prev_out.clone(),
             signatures: vec![signature],
             pub_keys: vec![pk],
-            address_version: Some(2),
         };
 
         let tx_ins = construct_payment_tx_ins(vec![tx_const]);
@@ -972,7 +884,6 @@ mod tests {
             previous_out: prev_out.clone(),
             signatures: vec![signature],
             pub_keys: vec![pk],
-            address_version: Some(2),
         };
 
         let drs_tx_hash = "item_tx_hash".to_string();
@@ -1020,7 +931,6 @@ mod tests {
             previous_out: prev_out.clone(),
             signatures: vec![signature],
             pub_keys: vec![pk],
-            address_version: Some(2),
         };
 
         let genesis_hash = "item_tx_hash".to_string();
@@ -1052,22 +962,6 @@ mod tests {
     #[test]
     // Creates a valid UTXO set
     fn test_construct_valid_utxo_set() {
-        test_construct_valid_utxo_set_common(None);
-    }
-
-    #[test]
-    // Creates a valid UTXO set
-    fn test_construct_valid_utxo_set_v0() {
-        test_construct_valid_utxo_set_common(Some(NETWORK_VERSION_V0));
-    }
-
-    #[test]
-    // Creates a valid UTXO set
-    fn test_construct_valid_utxo_set_temp() {
-        test_construct_valid_utxo_set_common(Some(NETWORK_VERSION_TEMP));
-    }
-
-    fn test_construct_valid_utxo_set_common(address_version: Option<u64>) {
         let (pk, sk) = sign::gen_keypair();
 
         let t_hash_1 = hex::encode(vec![0, 0, 0]);
@@ -1082,7 +976,6 @@ mod tests {
             previous_out: OutPoint::new("".to_string(), 0),
             signatures: vec![signed],
             pub_keys: vec![pk],
-            address_version,
         };
 
         let token_amount = TokenAmount(400000);
@@ -1106,7 +999,6 @@ mod tests {
             previous_out: tx_1_out_p.clone(),
             signatures: vec![signed],
             pub_keys: vec![pk],
-            address_version,
         };
         let tx_ins_2 = construct_payment_tx_ins(vec![tx_2]);
         let tx_outs = vec![TxOut::new_token_amount(
@@ -1134,22 +1026,6 @@ mod tests {
     #[test]
     // Creates a valid DDE transaction
     fn test_construct_a_valid_dde_tx() {
-        test_construct_a_valid_dde_tx_common(None);
-    }
-
-    #[test]
-    // Creates a valid DDE transaction
-    fn test_construct_a_valid_dde_tx_v0() {
-        test_construct_a_valid_dde_tx_common(Some(NETWORK_VERSION_V0));
-    }
-
-    #[test]
-    // Creates a valid DDE transaction
-    fn test_construct_a_valid_dde_tx_temp() {
-        test_construct_a_valid_dde_tx_common(Some(NETWORK_VERSION_TEMP));
-    }
-
-    fn test_construct_a_valid_dde_tx_common(address_version: Option<u64>) {
         let (_pk, sk) = sign::gen_keypair();
         let (pk, _sk) = sign::gen_keypair();
         let t_hash = hex::encode(vec![0, 0, 0]);
@@ -1169,7 +1045,6 @@ mod tests {
             previous_out: prev_out.clone(),
             signatures: vec![signature],
             pub_keys: vec![pk],
-            address_version,
         };
 
         let tx_ins = construct_payment_tx_ins(vec![tx_const]);
@@ -1312,22 +1187,6 @@ mod tests {
     #[test]
     // Test valid address construction; should correlate with test on wallet
     fn test_construct_valid_addresses() {
-        test_construct_valid_addresses_common(None);
-    }
-
-    #[test]
-    // Test valid address construction; should correlate with test on wallet
-    fn test_construct_valid_addresses_v0() {
-        test_construct_valid_addresses_common(Some(NETWORK_VERSION_V0));
-    }
-
-    #[test]
-    // Test valid address construction; should correlate with test on wallet
-    fn test_construct_valid_addresses_temp() {
-        test_construct_valid_addresses_common(Some(NETWORK_VERSION_TEMP));
-    }
-
-    fn test_construct_valid_addresses_common(address_version: Option<u64>) {
         //
         // Arrange
         //
@@ -1346,32 +1205,17 @@ mod tests {
         //
         let actual_pub_addresses: Vec<String> = pub_keys
             .iter()
-            .map(|pub_key| construct_address_for(pub_key, address_version))
+            .map(construct_address)
             .collect();
 
         //
         // Assert
         //
-        let expected_pub_addresses = match address_version {
-            // Old Address structure
-            Some(NETWORK_VERSION_V0) => vec![
-                "13bd3351b78beb2d0dadf2058dcc926c",
-                "abc7c0448465c4507faf2ee588728824",
-                "6ae52e3870884ab66ec49d3bb359c0bf",
-            ],
-            // Temporary address structure present on wallet
-            Some(NETWORK_VERSION_TEMP) => vec![
-                "6c6b6e8e9df8c63d22d9eb687b9671dd1ce5d89f195bb2316e1b1444848cd2b3",
-                "8ac2fdcb0688abb2727d63ed230665b275a1d3a28373baa92a9afa5afd610e9f",
-                "0becdaaf6a855f04961208ee992651c11df0be91c08629dfc079d05d2915ec22",
-            ],
-            // Current address structure
-            _ => vec![
-                "5423e6bd848e0ce5cd794e55235c23138d8833633cd2d7de7f4a10935178457b",
-                "77516e2d91606250e625546f86702510d2e893e4a27edfc932fdba03c955cc1b",
-                "4cfd64a6692021fc417368a866d33d94e1c806747f61ac85e0b3935e7d5ed925",
-            ],
-        };
+        let expected_pub_addresses = vec![
+            "5423e6bd848e0ce5cd794e55235c23138d8833633cd2d7de7f4a10935178457b",
+            "77516e2d91606250e625546f86702510d2e893e4a27edfc932fdba03c955cc1b",
+            "4cfd64a6692021fc417368a866d33d94e1c806747f61ac85e0b3935e7d5ed925",
+        ];
         assert_eq!(actual_pub_addresses, expected_pub_addresses);
     }
 
@@ -1472,7 +1316,7 @@ mod tests {
                     Signature::from_slice(hex::decode(signatures[n]).unwrap().as_ref()).unwrap();
                 let pk = PublicKey::from_slice(hex::decode(pub_keys[n]).unwrap().as_ref()).unwrap();
 
-                let script = Script::pay2pkh(hex::decode(&sig_data).unwrap(), sig, pk, None);
+                let script = Script::pay2pkh(hex::decode(&sig_data).unwrap(), sig, pk);
                 let out_p = previous_out_points[n].clone();
 
                 TxIn::new_from_input(out_p, script)


### PR DESCRIPTION
## Description
This PR depends on #50 (`script-bytes-not-strings`).

Much of the existing code contains multiple variants for three different kinds of address: default, "temp" and "v0". Both "temp" and "v0" are not used, and have been marked for removal for well over a year.

This PR completely removes them, and all code referencing address versions, so that all addresses are assumed to be of the "default" type.

## Changelog

- Removed functions and opcodes related to the two deprecated address versions
- Removed address version parameter from all applicable functions and structs
- Simplified tests which were duplicated for each of the three address versions into a single one

## Type of Change
Please mark the appropriate option by putting an "x" inside the brackets:

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement or optimization
- [ ] Documentation update
- [ ] Other (please specify)

## Checklist
Put an "x" in the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have tested the changes locally and they work as expected.
- [x] I have added necessary documentation or updated existing documentation.
- [x] My code follows the project's coding standards and style guidelines.
- [x] I have added/updated relevant tests to ensure the changes are properly covered.
- [x] I have checked for and resolved any merge conflicts.
- [x] My commits have clear and descriptive messages.

## Screenshots (if applicable)
If the changes affect the UI or have visual effects, please provide screenshots or GIFs showcasing the changes.

## Additional Context (if applicable)
Add any additional context or information about the changes that may be helpful in understanding the pull request.

## Related Issues (if applicable)
If this pull request is related to any existing issues, please list them here.

## Requested Reviewers
Mention any specific individuals or teams you would like to request a review from.